### PR TITLE
Added initial win32 configuration.

### DIFF
--- a/config-default-win32.json
+++ b/config-default-win32.json
@@ -1,0 +1,45 @@
+{
+  "command": "ping",
+  "args": ["-t"],
+  "events": {
+    "ping": {
+      "regexp": {
+        "string": "^Reply from ([0-9\\.:]+): bytes=([0-9\\.]+) time[<=]([0-9.]+)ms TTL=([0-9]+)",
+        "host": 1,
+        "bytes": 2,
+        "time": 3,
+        "ttl": 4
+      }
+    },
+    "start": {
+      "emits": ["start"],
+      "regexp": {
+        "string": "^Pinging (.*) \\[([0-9\\.:]+)\\] with ([0-9]+) bytes of data",
+        "domain": 1,
+        "host": 2,
+        "bytes": 3
+      }
+    },
+    "timedout": {
+      "emits": ["fail"],
+      "regexp": {
+        "string": "^Request timed out"
+      }
+    },
+    "hostnotfound": {
+      "emits": ["fail"],
+      "regexp": {
+        "string": "^Ping request could not find host ([0-9\\.:])",
+        "host": 1
+      }
+    },
+    "unreachable": {
+      "emits": ["fail"],
+      "regexp": {
+        "string": "^From ([0-9\\.:]+) icmp_seq=([0-9]+) Destination Host Unreachable",
+        "host": 1,
+        "icmp_seq": 2
+      }
+    }
+  }
+}


### PR DESCRIPTION
Should handle IPv6 pings, domain and ip.
I did notice sometimes on Windows 7, ping/node seems to put TTL on a
different event, maybe queue up the events till new lines are reached
and delimit by them as a work around.

However it still works for me.
